### PR TITLE
Fix framebox / rough graphics path rounding

### DIFF
--- a/packages/framebox/graphics/renderer.lua
+++ b/packages/framebox/graphics/renderer.lua
@@ -1,7 +1,7 @@
 --
 -- Some classes to build PDF graphics drawings (path strings)
 -- License: MIT
--- 2022, 2023 Didier Willis
+-- 2022, 2023, 2025 Didier Willis
 --
 -- Public API consists in:
 -- - a PathRenderer class that provides basic drawing methods, using a default
@@ -16,14 +16,14 @@ local PRNG = require("prng-prigarin")
 
 -- HELPERS
 
---- Round number
+--- Round number to string for output.
 --
 -- @tparam  number    number    number value
--- @return                      rounded value for output
+-- @treturn string              rounded value as string
 local function _r (number)
   -- Lua 5.3+ formats floats as 1.0 and integers as 1
   -- Also some PDF readers do not like double precision.
-  return math.floor(number) == number and math.floor(number) or tonumber(string.format("%.5f", number))
+  return math.floor(number) == number and tostring(math.floor(number)) or string.format("%.5f", number)
 end
 
 --- Builds a PDF graphics color (stroke or fill) from a SILE parsed color.
@@ -488,4 +488,3 @@ return {
   PathRenderer = PathRenderer,
   RoughPainter = RoughPainter,
 }
-

--- a/rockspecs/ptable.sile-3.1.1-1.rockspec
+++ b/rockspecs/ptable.sile-3.1.1-1.rockspec
@@ -1,0 +1,51 @@
+rockspec_format = "3.0"
+package = "ptable.sile"
+version = "3.1.1-1"
+source = {
+  url = "git+https://github.com/Omikhleia/ptable.sile.git",
+  tag = "v3.1.1",
+}
+description = {
+  summary = "Paragraph boxes, framed boxes and table packages for the SILE typesetting system.",
+  detailed = [[
+    This package for the SILE typesetter provides struts, paragraph boxes
+    (parbox), framed boxes (framebox) and tables (ptable).
+  ]],
+  homepage = "https://github.com/Omikhleia/ptable.sile",
+  license = "MIT",
+}
+dependencies = {
+  "lua >= 5.1",
+  "silex.sile >= 0.6.0, < 1.0",
+}
+build = {
+  type = "builtin",
+  modules = {
+    ["sile.packages.struts"]                      = "packages/struts/init.lua",
+    ["sile.packages.parbox"]                      = "packages/parbox/init.lua",
+    ["sile.packages.ptable"]                      = "packages/ptable/init.lua",
+    ["sile.packages.framebox"]                    = "packages/framebox/init.lua",
+    ["sile.packages.framebox.graphics.renderer"]  = "packages/framebox/graphics/renderer.lua",
+    ["sile.packages.framebox.graphics.rough"]     = "packages/framebox/graphics/rough.lua",
+    ["prng-prigarin"]                                  = "prng-prigarin/init.lua",
+    ["rough-lua.rough.jsshims"]                        = "rough-lua/rough/jsshims.lua",
+    ["rough-lua.rough.generator"]                      = "rough-lua/rough/generator.lua",
+    ["rough-lua.rough.renderer"]                       = "rough-lua/rough/renderer.lua",
+    ["rough-lua.rough.fillers.hachure-filler"]         = "rough-lua/rough/fillers/hachure-filler.lua",
+    ["rough-lua.rough.fillers.zigzag-filler"]          = "rough-lua/rough/fillers/zigzag-filler.lua",
+    ["rough-lua.rough.fillers.zigzag-line-filler"]     = "rough-lua/rough/fillers/zigzag-line-filler.lua",
+    ["rough-lua.rough.fillers.dot-filler"]             = "rough-lua/rough/fillers/dot-filler.lua",
+    ["rough-lua.rough.fillers.dashed-filler"]          = "rough-lua/rough/fillers/dashed-filler.lua",
+    ["rough-lua.rough.fillers.scan-line-hachure"]      = "rough-lua/rough/fillers/scan-line-hachure.lua",
+    ["rough-lua.rough.fillers.hatch-filler"]           = "rough-lua/rough/fillers/hatch-filler.lua",
+    ["rough-lua.rough.fillers.hachure-fill"]           = "rough-lua/rough/fillers/hachure-fill.lua",
+    ["rough-lua.rough.fillers.filler"]                 = "rough-lua/rough/fillers/filler.lua",
+    ["rough-lua.rough.geometry"]                       = "rough-lua/rough/geometry.lua",
+    ["rough-lua.untested.path-data-parser"]                 = "rough-lua/untested/path-data-parser/init.lua",
+    ["rough-lua.untested.path-data-parser.parser"]          = "rough-lua/untested/path-data-parser/parser.lua",
+    ["rough-lua.untested.path-data-parser.normalize"]       = "rough-lua/untested/path-data-parser/normalize.lua",
+    ["rough-lua.untested.path-data-parser.absolutize"]      = "rough-lua/untested/path-data-parser/absolutize.lua",
+    ["rough-lua.untested.points-on-curve"]                  = "rough-lua/untested/points-on-curve/init.lua",
+    ["rough-lua.untested.points-on-curve.curve-to-bezier"]  = "rough-lua/untested/points-on-curve/curve-to-bezier.lua",
+  }
+}


### PR DESCRIPTION
Some PDF readers do not like double precision numbers in graphics path and the PDF specification mentions an "implementation limit" at 5 decimals. We had a rounding function for this, but the implementation had a bug for small numbers close to 1e-5 -- They were actually output in exponent representation (e.g. `7e-5` instead of `0.00007`)[^1]

Some PDF readers do not like this at all either (e.g. Okular and Evince -- objects on the current page all fail to render afterwards). Other do not care (e.g. whatever Firefox or Chromium use), but this is "by chance" and not compliant to the PDF specification.

It didn't occur often, as the most common source for weird float values is the "rough" renderer -- and even when used, one has to be unlucky enough to fall on that edge case.

[^1]: Due to an extra call to `tonumber()` - it's aim was supposedly to remove useless digits, e.g. `0.05000` => `0.05` so as to keep numbers as short as possible, but it then defeats the preceding string formatting. The extra zeroes are not a problem, it seems (aside making the stream a bit longer).