### PR TITLE
feat: Support gradients for fill/stroke colors in framebox

### DIFF
--- a/examples/framebox-gradient.sil
+++ b/examples/framebox-gradient.sil
@@ -1,0 +1,82 @@
+\begin[papersize=a5,class=plain]{document}
+\neverindent
+\nofolios
+\use[module=packages.parbox]
+\use[module=packages.framebox]
+\use[module=packages.leaders]
+\language[main=en]
+\font[family=Libertinus Serif, size=14]
+
+\center{\font[weight=700]{Do Boxes With Gradients Rock?}}
+
+\bigskip
+
+\begin{center}
+\begin[side=both, bracecolor=flare 90, curvyness=0.7, padding=1em, bracethickness=0.1em, bracewidth=0.4em]{bracebox}
+\begin[valign=middle,width=80%fw,minimize=true]{parbox}
+\begin{center}
+\font[weight=700]{Sherlock Holmes}\par
+221b Baker Street — London NW1 6XE\par
+sherlock.holmes@sile.org\par
+\end{center}
+\end{parbox}
+\end{bracebox}
+\end{center}
+
+\bigskip
+
+\begin{center}
+\begin[padding=1em, shadow=true, borderwidth=0, fillcolor=metallicsteel 90, shadowcolor=200]{framebox}
+\begin[valign=middle,width=80%fw,minimize=true]{parbox}
+\begin{center}
+\font[weight=700]{Sherlock Holmes}\par
+221b Baker Street — London NW1 6XE\par
+sherlock.holmes@sile.org\par
+\end{center}
+\end{parbox}
+\end{framebox}
+\end{center}
+
+\bigskip
+
+\begin{center}
+\begin[padding=1em, shadow=true, borderwidth=0, fillcolor=omissible, shadowcolor=200, cornersize=20pt]{roundbox}
+\begin[valign=middle,width=80%fw,minimize=true]{parbox}
+\begin{center}
+\font[weight=700]{Sherlock Holmes}\par
+221b Baker Street — London NW1 6XE\par
+sherlock.holmes@sile.org\par
+\end{center}
+\end{parbox}
+\end{roundbox}
+\end{center}
+
+\bigskip
+
+\begin{center}
+\begin[padding=1em, bordercolor=metallicsteel 90, fillcolor=omissiblecopper 90, enlarge=true]{roughbox}
+\begin[valign=middle,width=80%fw,minimize=true]{parbox}
+\begin{center}
+\font[weight=700]{Sherlock Holmes}\par
+221b Baker Street — London NW1 6XE\par
+sherlock.holmes@sile.org\par
+\end{center}
+\end{parbox}
+\end{roughbox}
+\end{center}
+
+\bigskip
+
+\begin{center}
+\begin[padding=1em, bordercolor=gray, fillcolor=crest, fillstyle=cross-hatch, enlarge=true]{roughbox}
+\begin[valign=middle,width=80%fw,minimize=true]{parbox}
+\begin{center}
+\font[weight=700]{Sherlock Holmes}\par
+221b Baker Street — London NW1 6XE\par
+sherlock.holmes@sile.org\par
+\end{center}
+\end{parbox}
+\end{roughbox}
+\end{center}
+
+\end{document}

--- a/packages/framebox/init.lua
+++ b/packages/framebox/init.lua
@@ -8,10 +8,24 @@
 --
 local PathRenderer = require("grail.renderer")
 local RoughPainter = require("grail.painters.rough")
+local Color = require("grail.color")
 
 local base = require("packages.base")
 local package = pl.class(base)
 package._name = "framebox"
+
+function package:loadOptPackage (pack)
+   local ok, _ = pcall(function ()
+      self:loadPackage(pack)
+      return true
+   end)
+   return ok
+end
+
+function package:_init ()
+  base._init(self)
+  self:loadOptPackage("resilient.gradients")
+end
 
 -- LOW-LEVEL REBOXING HELPERS
 
@@ -51,37 +65,48 @@ end
 -- @tparam array      hlist        Migrating node list
 -- @tparam number|nil shadowsize   Shadow size (in points)
 -- @tparam function   pathfn       Path construction calback
-local function frameHbox (hbox, hlist, shadowsize, pathfn)
+function package:_frameHbox (hbox, hlist, shadowsize, pathfn)
   local shadowpadding = shadowsize or 0
   SILE.typesetter:pushHbox({
     inner = hbox,
     width = hbox.width,
     height = hbox.height,
     depth = hbox.depth,
-    outputYourself = function (self, typesetter, line)
+    outputYourself = function (box, typesetter, line)
       local saveX = typesetter.frame.state.cursorX
       local saveY = typesetter.frame.state.cursorY
       -- Scale to line to take into account strech/shrinkability
-      local outputWidth = self:scaledWidth(line)
+      local outputWidth = box:scaledWidth(line)
       -- Force advancing to get the new cursor position
       typesetter.frame:advanceWritingDirection(outputWidth)
       local newX = typesetter.frame.state.cursorX
 
       -- Compute the target width, height, depth for the frame
       local w = (newX - saveX):tonumber() - shadowpadding
-      local h = self.height:tonumber()
-      local d = self.depth:tonumber() - shadowpadding
+      local h = box.height:tonumber()
+      local d = box.depth:tonumber() - shadowpadding
+      local H = h + d
 
       -- Compute and draw the PDF graphics (path)
-      local path = pathfn(w, h, d)
+      local path, grads = pathfn(w, h, d)
       if path then
-        SILE.outputter:drawSVG(path, saveX, saveY, w, h + d, 1)
+        local pkg = self.class.packages["resilient.gradients"]
+        if grads and #grads > 0 then
+          if pkg then
+            for _, grad in ipairs(grads) do
+              pkg:outputGradient(grad, saveX:tonumber(), saveY:tonumber() + d, saveX:tonumber() + w, saveY:tonumber() + H + d)
+            end
+          else
+            SU.warn("Gradient package not loaded, gradients will not be rendered.")
+          end
+        end
+        SILE.outputter:drawSVG(path, saveX, saveY, w, H, 1)
       end
 
       -- Restore cursor position and output the content last (so it appears
       -- on top of the frame)
       typesetter.frame.state.cursorX = saveX
-      self.inner:outputYourself(typesetter, line)
+      box.inner:outputYourself(typesetter, line)
       typesetter.frame.state.cursorX = newX
     end
   })
@@ -128,29 +153,37 @@ function package:registerCommands ()
     local borderwidth = SU.cast("measurement", options.borderwidth or SILE.settings:get("framebox.borderwidth")):tonumber()
     local bordercolor
     if borderwidth ~= 0 then
-      bordercolor = options.bordercolor and SILE.types.color(options.bordercolor)
+      bordercolor = options.bordercolor and Color(options.bordercolor)
     end
-    local fillcolor = options.fillcolor and SILE.types.color(options.fillcolor) or 'none'
+    local fillcolor = options.fillcolor and Color(options.fillcolor) or 'none'
     local shadow = SU.boolean(options.shadow, false)
     local shadowsize = shadow and SU.cast("measurement", options.shadowsize or SILE.settings:get("framebox.shadowsize")):tonumber() or 0
-    local shadowcolor = shadow and options.shadowcolor and SILE.types.color(options.shadowcolor)
+    local shadowcolor = shadow and options.shadowcolor and Color(options.shadowcolor)
 
     local hbox, hlist = SILE.typesetter:makeHbox(content)
     hbox = adjustPaddingHbox(hbox, padding, padding + shadowsize, padding, padding + shadowsize)
 
-    frameHbox(hbox, hlist, shadowsize, function (w, h, d)
+    self:_frameHbox(hbox, hlist, shadowsize, function (w, h, d)
       local painter = PathRenderer()
-      local shadowpath, path
+      local shadowpath, path, shadowgrad, grad
       if shadowsize ~= 0 then
-        shadowpath = painter:rectangleShadow(0, d, w , h + d, shadowsize, {
+        shadowpath, shadowgrad = painter:rectangleShadow(0, d, w , h + d, shadowsize, {
           fill = shadowcolor,
           stroke = 'none'
         })
       end
-      path = painter:rectangle(0, d , w , h + d, {
+      path, grad = painter:rectangle(0, d , w , h + d, {
         fill = fillcolor, stroke = bordercolor, strokeWidth = borderwidth
       })
-      return shadowpath and shadowpath .. " " .. path or path
+      path = shadowpath and (shadowpath .. " " .. path) or path
+      if shadowgrad then
+        if grad then
+          pl.tablex.insertvalues(grad, shadowgrad)
+        else
+          grad = shadowgrad
+        end
+      end
+      return path, grad
     end)
   end, "Frames content in a square box.")
 
@@ -159,35 +192,43 @@ function package:registerCommands ()
     local borderwidth = SU.cast("measurement", options.borderwidth or SILE.settings:get("framebox.borderwidth")):tonumber()
     local bordercolor
     if borderwidth ~= 0 then
-      bordercolor = options.bordercolor and SILE.types.color(options.bordercolor)
+      bordercolor = options.bordercolor and Color(options.bordercolor)
     end
-    local fillcolor = options.fillcolor and SILE.types.color(options.fillcolor) or 'none'
+    local fillcolor = options.fillcolor and Color(options.fillcolor) or 'none'
     local shadow = SU.boolean(options.shadow, false)
     local shadowsize = shadow and SU.cast("measurement", options.shadowsize or SILE.settings:get("framebox.shadowsize")):tonumber() or 0
-    local shadowcolor = shadow and options.shadowcolor and SILE.types.color(options.shadowcolor)
+    local shadowcolor = shadow and options.shadowcolor and Color(options.shadowcolor)
 
     local cornersize = SU.cast("measurement", options.cornersize or SILE.settings:get("framebox.cornersize")):tonumber()
 
     local hbox, hlist = SILE.typesetter:makeHbox(content)
     hbox = adjustPaddingHbox(hbox, padding, padding + shadowsize, padding, padding + shadowsize)
 
-    frameHbox(hbox, hlist, shadowsize, function (w, h, d)
+    self:_frameHbox(hbox, hlist, shadowsize, function (w, h, d)
       local H = h + d
       local smallest = w < H and w or H
       cornersize = cornersize < 0.5 * smallest and cornersize or math.floor(0.5 * smallest)
 
       local painter = PathRenderer()
-      local shadowpath, path
+      local shadowpath, path, shadowgrad, grad
       if shadowsize ~= 0 then
-        shadowpath = painter:roundedRectangleShadow(0, d , w , H, cornersize, cornersize, shadowsize, {
+        shadowpath, shadowgrad = painter:roundedRectangleShadow(0, d , w , H, cornersize, cornersize, shadowsize, {
           fill = shadowcolor,
           stroke = 'none'
         })
       end
-      path = painter:roundedRectangle(0, d , w , H, cornersize, cornersize, {
+      path, grad = painter:roundedRectangle(0, d , w , H, cornersize, cornersize, {
         fill = fillcolor, stroke = bordercolor, strokeWidth = borderwidth
       })
-      return shadowpath and shadowpath .. " " .. path or path
+      path = shadowpath and (shadowpath .. " " .. path) or path
+      if shadowgrad then
+        if grad then
+          pl.tablex.insertvalues(grad, shadowgrad)
+        else
+          grad = shadowgrad
+        end
+      end
+      return path, grad
     end)
   end, "Frames content in a rounded box.")
 
@@ -201,8 +242,8 @@ function package:registerCommands ()
       -- (for hachures etc.)
       borderwidth = SILE.settings:get("framebox.borderwidth"):tonumber()
     end
-    local bordercolor = options.bordercolor and SILE.types.color(options.bordercolor)
-    local fillcolor = options.fillcolor and SILE.types.color(options.fillcolor)
+    local bordercolor = options.bordercolor and Color(options.bordercolor)
+    local fillcolor = options.fillcolor and Color(options.fillcolor)
     local enlarge = SU.boolean(options.enlarge, false)
 
     local hbox, hlist = SILE.typesetter:makeHbox(content)
@@ -221,7 +262,7 @@ function package:registerCommands ()
       fillStyle = options.fillstyle or 'hachure'
     }
 
-    frameHbox(hbox, hlist, nil, function (w, h, d)
+    self:_frameHbox(hbox, hlist, nil, function (w, h, d)
       local H = h + d
       local x = 0
       local y = d
@@ -239,7 +280,7 @@ function package:registerCommands ()
   self:registerCommand("bracebox", function (options, content)
     local padding = SU.cast("measurement", options.padding or SILE.types.measurement("0.25em")):tonumber()
     local strokewidth = SU.cast("measurement", options.strokewidth or SILE.types.measurement("0.033em")):tonumber()
-    local bracecolor = options.bracecolor and SILE.types.color(options.bracecolor)
+    local bracecolor = options.bracecolor and Color(options.bracecolor)
     local bracewidth = SU.cast("measurement", options.bracewidth or SILE.types.measurement("0.25em")):tonumber()
     local bracethickness = SU.cast("measurement", options.bracethickness or SILE.types.measurement("0.05em")):tonumber()
     local curvyness = SU.cast("number", options.curvyness or 0.6)
@@ -252,24 +293,33 @@ function package:registerCommands ()
     local hbox, hlist = SILE.typesetter:makeHbox(content)
     hbox = adjustPaddingHbox(hbox, left and bracewidth + padding or 0, right and bracewidth + padding or 0, 0, 0)
 
-    frameHbox(hbox, hlist, nil, function (w, h, d)
+    self:_frameHbox(hbox, hlist, nil, function (w, h, d)
       local painter = PathRenderer()
-      local lb, rb
+      local lb, rb, lgrad, rgrad
       if left then
-        lb = painter:curlyBrace(bracewidth, d, bracewidth, 2*d+h, bracewidth, bracethickness, curvyness, {
+        lb, lgrad = painter:curlyBrace(bracewidth, d, bracewidth, 2*d+h, bracewidth, bracethickness, curvyness, {
           fill = bracecolor,
           stroke = bracecolor,
           strokeWidth = strokewidth
         })
       end
       if right then
-        rb = painter:curlyBrace(w-bracewidth, d, w-bracewidth, 2*d+h, -bracewidth, bracethickness, curvyness, {
+        rb, rgrad= painter:curlyBrace(w-bracewidth, d, w-bracewidth, 2*d+h, -bracewidth, bracethickness, curvyness, {
           fill = bracecolor,
           stroke = bracecolor,
           strokeWidth = strokewidth
         })
       end
-      return lb and (rb and lb .. " " .. rb or lb) or rb
+      local path = lb and (rb and lb .. " " .. rb or lb) or rb
+      local grad = lgrad
+      if rgrad then
+        if grad then
+          pl.tablex.insertvalues(grad, rgrad)
+        else
+          grad = rgrad
+        end
+      end
+      return path, grad
     end)
   end, "Frames content in a box with curly brace(s).")
 

--- a/rockspecs/ptable.sile-4.2.0-1.rockspec
+++ b/rockspecs/ptable.sile-4.2.0-1.rockspec
@@ -1,0 +1,31 @@
+rockspec_format = "3.0"
+package = "ptable.sile"
+version = "4.2.0-1"
+source = {
+  url = "git+https://github.com/Omikhleia/ptable.sile.git",
+  tag = "v4.2.0",
+}
+description = {
+  summary = "Paragraph boxes, framed boxes and table packages for the SILE typesetting system.",
+  detailed = [[
+    This package for the SILE typesetter provides struts, paragraph boxes
+    (parbox), framed boxes (framebox) and tables (ptable).
+  ]],
+  homepage = "https://github.com/Omikhleia/ptable.sile",
+  license = "MIT",
+}
+dependencies = {
+  "lua >= 5.1",
+  "grail >= 1.1"
+}
+build = {
+  type = "builtin",
+  modules = {
+    ["sile.packages.struts"]                      = "packages/struts/init.lua",
+    ["sile.packages.parbox"]                      = "packages/parbox/init.lua",
+    ["sile.packages.ptable"]                      = "packages/ptable/init.lua",
+    ["sile.packages.framebox"]                    = "packages/framebox/init.lua",
+    ["sile.packages.framebox.graphics.renderer"]  = "packages/framebox/graphics/renderer.lua",
+    ["sile.packages.framebox.graphics.rough"]     = "packages/framebox/graphics/rough.lua",
+  }
+}


### PR DESCRIPTION
Based on grail v1.1.0 which added gradient support to drawing constructs. If optional package resilient.gradients is available, these gradients can now be rendered.

See 
 - https://github.com/Omikhleia/grail/pull/2 (support at the Grail library level)
 - https://github.com/Omikhleia/resilient.sile/pull/194 (support at the resilient level)

Support:
 - [x] framebox
 - ~~parbox~~
 - ~~ptable~~

The interest of the use case for **ptable** and **parbox** is less obvious. It may be provided if there's really a need, but we could start without it.